### PR TITLE
ci: adjust renovate to stop annoying node update PRs

### DIFF
--- a/.github/workflows/firebase-live.yml
+++ b/.github/workflows/firebase-live.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22.14.0'
+          node-version: '22'
           cache: 'pnpm'
 
       - run: pnpm install

--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22.14.0'
+          node-version: '22'
           cache: 'pnpm'
 
       - run: pnpm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22.14.0'
+          node-version: '22'
           cache: 'pnpm'
 
       - run: pnpm install

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,10 @@
       "enabled": false
     },
     {
+      "matchDatasources": ["node-version"],
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["vitepress"],
       "groupName": "vitepress"
     },


### PR DESCRIPTION
Aimed at stopping annoying PRs like #54 since clearly the following doesn't stop it:

https://github.com/api3dao/dao-docs/blob/6cfb5beca6d42618b490944d6f06171301cf7d89/renovate.json#L4-L8